### PR TITLE
Capitalize bundle name in Info.plist

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>locus</string>
+	<string>Locus</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
In some apps like [Scarlet](https://usescarlet.com), `CFBundleName` is used instead of `CFBundleDisplayName` to show the name of the app. (They're not supposed to - `CFBundleDisplayName` is preferred over `CFBundleName` - but oh well!)