### PR TITLE
Change URL scheme from fossapp394:// to locus://

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -35,7 +35,7 @@
 			<string>locus</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>fossapp394</string>
+				<string>locus</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
Begins to handle but does not close #147. I can't seem to find any `locus.cfd` code in this repository so I'm assuming it's not FLOSS like the rest of Locus (which is a shame!)